### PR TITLE
Rename filter classes for consistency

### DIFF
--- a/aiklyra/graph/filters/__init__.py
+++ b/aiklyra/graph/filters/__init__.py
@@ -1,4 +1,4 @@
 from .base_filter import BaseGraphFilter
-from .fr_filter import FRFilter
-from .topk_filter import TopKFilter
-from .threshold_filter import ThresholdFilter
+from .filter_fr import FilterFR
+from .filter_topk import FilterTopK
+from .filter_threshold import FilterThreshold

--- a/aiklyra/graph/filters/filter_fr.py
+++ b/aiklyra/graph/filters/filter_fr.py
@@ -4,7 +4,7 @@ import numpy as np
 from typing import Dict
 
 
-class FRFilter(BaseGraphFilter):
+class FilterFR(BaseGraphFilter):
     """
     A filter that performs edge filtering based on weight, removes cycles, 
     and reconnects disconnected subgraphs using the transition matrix.
@@ -16,7 +16,7 @@ class FRFilter(BaseGraphFilter):
 
     def __init__(self, min_weight: float = 0.0, top_k: int = 5):
         """
-        Initialize the FRFilter.
+        Initialize the FilterFR.
 
         Args:
             min_weight (float): Minimum weight threshold for keeping edges. Defaults to 0.0.
@@ -88,7 +88,7 @@ class FRFilter(BaseGraphFilter):
                                             [0.0, 0.0, 0.8],
                                             [0.0, 0.0, 0.0]])
             >>> intent_by_cluster = {"0": "Intent A", "1": "Intent B", "2": "Intent C"}
-            >>> filter = FRFilter(min_weight=0.3, top_k=1)
+            >>> filter = FilterFR(min_weight=0.3, top_k=1)
             >>> processed_graph = filter.apply(graph, transition_matrix, intent_by_cluster)
             >>> list(processed_graph.edges(data=True))
             [('Intent A', 'Intent B', {'weight': 0.5}),

--- a/aiklyra/graph/filters/filter_threshold.py
+++ b/aiklyra/graph/filters/filter_threshold.py
@@ -3,7 +3,7 @@ import networkx as nx
 import numpy as np
 from typing import Dict
 
-class ThresholdFilter(BaseGraphFilter):
+class FilterThreshold(BaseGraphFilter):
     """
     A filter that removes edges from a graph whose weights are below a specified threshold.
 
@@ -13,7 +13,7 @@ class ThresholdFilter(BaseGraphFilter):
 
     def __init__(self, threshold: float):
         """
-        Initialize the ThresholdFilter.
+        Initialize the FilterThreshold.
 
         Args:
             threshold (float): The minimum weight threshold for edges (0 < threshold <= 1). 
@@ -63,13 +63,13 @@ class ThresholdFilter(BaseGraphFilter):
             >>> graph.add_edge("Node A", "Node B", weight=0.5)
             >>> graph.add_edge("Node A", "Node C", weight=0.2)
             >>> graph.add_edge("Node B", "Node C", weight=0.8)
-            >>> threshold_filter = ThresholdFilter(threshold=0.3)
+            >>> threshold_filter = FilterThreshold(threshold=0.3)
             >>> filtered_graph = threshold_filter.apply(graph, None, None)
             >>> list(filtered_graph.edges(data=True))
             [('Node A', 'Node B', {'weight': 0.5}), ('Node B', 'Node C', {'weight': 0.8})]
 
         Notes:
-            - The threshold value is determined when the `ThresholdFilter` object is initialized.
+            - The threshold value is determined when the `FilterThreshold` object is initialized.
             - If no edges meet the threshold criteria, the resulting graph may contain nodes but no edges.
             - The method assumes that all edges in the graph have a 'weight' attribute. If the attribute
               is missing, an exception may be raised.

--- a/aiklyra/graph/filters/filter_topk.py
+++ b/aiklyra/graph/filters/filter_topk.py
@@ -3,7 +3,7 @@ import networkx as nx
 import numpy as np
 from typing import Dict
 
-class TopKFilter(BaseGraphFilter):
+class FilterTopK(BaseGraphFilter):
     """
     A filter that retains only the top K outgoing edges for each node in a directed graph,
     based on edge weights.
@@ -14,7 +14,7 @@ class TopKFilter(BaseGraphFilter):
 
     def __init__(self, top_k: int):
         """
-        Initialize the TopKFilter.
+        Initialize the FilterTopK.
 
         Args:
             top_k (int): The number of top outgoing edges to retain for each node.
@@ -53,7 +53,7 @@ class TopKFilter(BaseGraphFilter):
             >>> graph.add_edge(0, 2, weight=0.2)
             >>> graph.add_edge(0, 3, weight=0.8)
             >>> graph.add_edge(1, 2, weight=0.3)
-            >>> filter = TopKFilter(top_k=2)
+            >>> filter = FilterTopK(top_k=2)
             >>> filtered_graph = filter.apply(graph, None, None)
             >>> list(filtered_graph.edges(data=True))
             [(0, 3, {'weight': 0.8}), (0, 1, {'weight': 0.5}), (1, 2, {'weight': 0.3})]

--- a/tests/test_graph_processing.py
+++ b/tests/test_graph_processing.py
@@ -1,7 +1,7 @@
 import pytest
 import networkx as nx
 import numpy as np
-from aiklyra import GraphProcessor, FRFilter, ThresholdFilter
+from aiklyra import GraphProcessor, FilterFR, FilterThreshold
 
 
 @pytest.fixture
@@ -31,12 +31,12 @@ def setup_data():
 
 def test_threshold_filter(setup_data):
     """
-    Test the ThresholdFilter to ensure it removes edges below the threshold.
+    Test the FilterThreshold to ensure it removes edges below the threshold.
     """
     graph, transition_matrix, intent_by_cluster = setup_data
 
     # Apply a threshold filter
-    threshold_filter = ThresholdFilter(threshold=0.3)
+    threshold_filter = FilterThreshold(threshold=0.3)
     filtered_graph = threshold_filter.apply(graph, transition_matrix, intent_by_cluster)
 
     # Check edges in the filtered graph
@@ -47,12 +47,12 @@ def test_threshold_filter(setup_data):
 
 def test_fr_filter(setup_data):
     """
-    Test the FRFilter for filtering, cycle removal, and subgraph reconnection.
+    Test the FilterFR for filtering, cycle removal, and subgraph reconnection.
     """
     graph, transition_matrix, intent_by_cluster = setup_data
 
-    # Apply the FRFilter
-    fr_filter = FRFilter(min_weight=0.3, top_k=2)
+    # Apply the FilterFR
+    fr_filter = FilterFR(min_weight=0.3, top_k=2)
     processed_graph = fr_filter.apply(graph, transition_matrix, intent_by_cluster)
 
     # Validate that cycles are removed
@@ -69,12 +69,12 @@ def test_combined_filters(setup_data):
     """
     graph, transition_matrix, intent_by_cluster = setup_data
 
-    # Step 1: Apply ThresholdFilter
-    threshold_filter = ThresholdFilter(threshold=0.3)
+    # Step 1: Apply FilterThreshold
+    threshold_filter = FilterThreshold(threshold=0.3)
     filtered_graph = threshold_filter.apply(graph, transition_matrix, intent_by_cluster)
 
-    # Step 2: Apply FRFilter
-    fr_filter = FRFilter(min_weight=0.3, top_k=2)
+    # Step 2: Apply FilterFR
+    fr_filter = FilterFR(min_weight=0.3, top_k=2)
     final_graph = fr_filter.apply(filtered_graph, transition_matrix, intent_by_cluster)
 
     # Validate that cycles are removed
@@ -97,16 +97,16 @@ def test_edge_case_empty_graph():
     transition_matrix = np.array([])
     intent_by_cluster = {}
 
-    # Apply ThresholdFilter
-    threshold_filter = ThresholdFilter(threshold=1)
+    # Apply FilterThreshold
+    threshold_filter = FilterThreshold(threshold=1)
     filtered_graph = threshold_filter.apply(empty_graph, transition_matrix, intent_by_cluster)
 
     # Validate the result is still an empty graph
     assert filtered_graph.number_of_nodes() == 0
     assert filtered_graph.number_of_edges() == 0
 
-    # Apply FRFilter
-    fr_filter = FRFilter(min_weight=1, top_k=2)
+    # Apply FilterFR
+    fr_filter = FilterFR(min_weight=1, top_k=2)
     processed_graph = fr_filter.apply(empty_graph, transition_matrix, intent_by_cluster)
 
     # Validate the result is still an empty graph

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,7 +3,7 @@ import json
 from unittest.mock import patch, MagicMock
 import numpy as np
 from difflib import SequenceMatcher
-from aiklyra import AiklyraClient, GraphProcessor, FRFilter
+from aiklyra import AiklyraClient, GraphProcessor, FilterFR
 
 
 @pytest.fixture
@@ -109,7 +109,7 @@ def test_overall_library_with_tolerance(mock_post, mock_conversation_data, mock_
     graph_processor = GraphProcessor(analysis)
 
     # Apply filters to the graph
-    filter_and_reconnect = FRFilter(min_weight=0.1, top_k=1)
+    filter_and_reconnect = FilterFR(min_weight=0.1, top_k=1)
     graph_processor.filter_graph(filter_strategy=filter_and_reconnect)
 
     # Verify that the graph is processed without errors


### PR DESCRIPTION
Fixes #20

Filter Classes and References renamed to have consist convention starting with "Filter"

<img width="585" alt="image" src="https://github.com/user-attachments/assets/397f77a7-e98d-4d25-ab04-062334c52c0d" />


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/aiklyra/aiklyra/pull/33?shareId=dee866c2-317c-41f5-9176-3a533d758c6f).